### PR TITLE
Add license refrence to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,8 @@ NCBounds is a Python module able to compute worst-case performances upper bounds
 
 ## Installation:
 ``` sudo python3 ./setup.py install```
+
+
+## License
+
+This project is licensed under the BSD-3-Clause license - see the [LICENSE](https://github.com/nokia/NCBounds/blob/master/LICENSE).


### PR DESCRIPTION
Adds a refrence to the project license to README.md. This is considered a best-practice.